### PR TITLE
Fix Actions build breaks

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -20,7 +20,6 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-
     - name: Install environment
       uses: ruby/setup-ruby@v1.52.0
       with:
@@ -30,11 +29,13 @@ jobs:
     - name: Build Jekyll
       run: |
         bundle exec jekyll build --config _config.staging.yml
+        
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_site
+
     - name: Deployment Action
       # You may pin to the exact commit or the version.
       # uses: chrnorm/deployment-action@0a0479c8ab41cd336ddc266342ca0a1c54727a72

--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -25,6 +25,7 @@ jobs:
       uses: ruby/setup-ruby@v1.52.0
       with:
         bundler-cache: true
+        ruby-version: 2.7 
 
     - name: Build Jekyll
       run: |

--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -20,9 +20,6 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: Ruby setup
-      uses: actions/setup-ruby@v1.0.0
-
     - name: Bundle install
       run: | 
         gem install bundler 

--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -22,7 +22,6 @@ jobs:
 
     - name: Bundle install
       run: | 
-        gem install bundler 
         bundle install
 
     - name: Build Jekyll

--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -20,9 +20,11 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: Bundle install
-      run: | 
-        bundle install
+
+    - name: Install environment
+      uses: ruby/setup-ruby@v1.52.0
+      with:
+        bundler-cache: true
 
     - name: Build Jekyll
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,13 +22,16 @@ jobs:
     - name: Ruby setup
       uses: actions/setup-ruby@v1.0.0
 
-    - name: Bundle install
-      run: | 
-        gem install bundler 
-        bundle install
+    - name: Install environment
+      uses: ruby/setup-ruby@v1.52.0
+      with:
+        bundler-cache: true
+        ruby-version: 2.7 
+        
     - name: Build Jekyll
       run: |
         bundle exec jekyll build --config _config.release.yml
+        
     - name: ftp-action
       uses: sebastianpopp/ftp-action@v2.0.0
       with:
@@ -40,6 +43,7 @@ jobs:
         forceSsl: true
         localDir: ./_site
         remoteDir: .
+        
     - name: Deployment 
       # You may pin to the exact commit or the version.
       # uses: chrnorm/deployment-action@0a0479c8ab41cd336ddc266342ca0a1c54727a72

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+
+    - name: Install environment
+      uses: ruby/setup-ruby@v1.52.0
       with:
-        ruby-version: 2.6
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true
+        ruby-version: 2.7 
+        
     - name: Run tests
       run: rake test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,8 @@ jobs:
         bundler-cache: true
         ruby-version: 2.7 
         
+    - name : Install html-proofer
+      run: gem install html-proofer
+        
     - name: Run tests
       run: rake test

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :jekyll_plugins do
   gem "jekyll-github-metadata"
   gem "html-proofer"
   gem "jekyll-paginate-v2"
+  gem "html-proofer"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,10 @@ group :jekyll_plugins do
   gem "jekyll-github-metadata"
   gem "html-proofer"
   gem "jekyll-paginate-v2"
-  gem "html-proofer"
 end
+
+gem "html-proofer"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,9 +48,6 @@ GEM
     jekyll-github-metadata (2.13.0)
       jekyll (>= 3.4, < 5.0)
       octokit (~> 4.0, != 4.4.0)
-    jekyll-last-modified-at (1.3.0)
-      jekyll (>= 3.7, < 5.0)
-      posix-spawn (~> 0.3.9)
     jekyll-paginate-v2 (3.0.0)
       jekyll (>= 3.0, < 5.0)
     jekyll-sass-converter (2.1.0)
@@ -86,7 +83,6 @@ GEM
     parallel (1.19.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.15)
     public_suffix (4.0.5)
     rainbow (3.0.0)
     rb-fsevent (0.10.4)
@@ -122,7 +118,6 @@ DEPENDENCIES
   jekyll (~> 4.1.1)
   jekyll-feed
   jekyll-github-metadata
-  jekyll-last-modified-at
   jekyll-paginate-v2
   jekyll-seo-tag
   minima (~> 2.0)


### PR DESCRIPTION
GitHub Actions deprecated specific features around `set-env`, so our builds are all broken at the moment. This PR will fix those. 